### PR TITLE
Add report generation and file existence check

### DIFF
--- a/src/main/java/bc/bfi/google_places/Main.java
+++ b/src/main/java/bc/bfi/google_places/Main.java
@@ -204,6 +204,13 @@ public class Main extends javax.swing.JFrame {
     private void jButtonStartActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonStartActionPerformed
         this.serperScraper = new SerperScraper(queries, config);
 
+        // Check if report.csv already exists
+        Path reportPath = Paths.get("report.csv");
+        if (Files.exists(reportPath)) {
+            JOptionPane.showMessageDialog(null, "Please remove the report.csv file before start.", "Warning", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
         if (this.jTextAreaQueries.getText().isEmpty()) {
             JOptionPane.showMessageDialog(null, "Queries are not loaded.", "Warding", JOptionPane.WARNING_MESSAGE);
             return;
@@ -240,6 +247,8 @@ public class Main extends javax.swing.JFrame {
                 googlePlaceScraper.startScrape();
                 break;
         }
+
+        new ReportGenerator().generate(Paths.get("initial-.csv"), reportPath);
 
         this.jTextFieldFinishTime.setText(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
         JOptionPane.showMessageDialog(null, "Scrape process completed.", "Done", JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/bc/bfi/google_places/ReportGenerator.java
+++ b/src/main/java/bc/bfi/google_places/ReportGenerator.java
@@ -1,0 +1,151 @@
+package bc.bfi.google_places;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.DecimalFormat;
+import java.util.Locale;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+
+/**
+ * Generates a report with statistics about scraped places.
+ */
+public class ReportGenerator {
+
+    /**
+     * Generates report CSV file based on provided CSV data file.
+     *
+     * @param dataPath   path to CSV file with scraped data
+     * @param reportPath path to output report.csv
+     */
+    public void generate(Path dataPath, Path reportPath) {
+        int total = 0;
+        int noType = 0;
+        int noName = 0;
+        int noFullAddress = 0;
+        int noLatitude = 0;
+        int noLongitude = 0;
+        int noRate = 0;
+        int noReviews = 0;
+        int noPhone = 0;
+        int noWebsite = 0;
+        int brokenLatitude = 0;
+        int brokenLongitude = 0;
+        int brokenRate = 0;
+        int brokenReviews = 0;
+        int brokenPhone = 0;
+
+        try (Reader reader = Files.newBufferedReader(dataPath, StandardCharsets.UTF_8);
+                CSVParser parser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader())) {
+            for (CSVRecord record : parser) {
+                total++;
+                String type = record.get("TYPE").trim();
+                if (type.isEmpty()) {
+                    noType++;
+                }
+                String name = record.get("NAME").trim();
+                if (name.isEmpty()) {
+                    noName++;
+                }
+                String fullAddress = record.get("FULL_ADDRESS").trim();
+                if (fullAddress.isEmpty()) {
+                    noFullAddress++;
+                }
+                String latitude = record.get("LATITUDE").trim();
+                if (latitude.isEmpty()) {
+                    noLatitude++;
+                } else if (!isDouble(latitude)) {
+                    brokenLatitude++;
+                }
+                String longitude = record.get("LONGITUDE").trim();
+                if (longitude.isEmpty()) {
+                    noLongitude++;
+                } else if (!isDouble(longitude)) {
+                    brokenLongitude++;
+                }
+                String rate = record.get("RATE").trim();
+                if (rate.isEmpty()) {
+                    noRate++;
+                } else if (!isDouble(rate)) {
+                    brokenRate++;
+                }
+                String reviews = record.get("REVIEWS").trim();
+                if (reviews.isEmpty()) {
+                    noReviews++;
+                } else if (!isInteger(reviews)) {
+                    brokenReviews++;
+                }
+                String phone = record.get("PHONE").trim();
+                if (phone.isEmpty()) {
+                    noPhone++;
+                } else if (!isPhone(phone)) {
+                    brokenPhone++;
+                }
+                String website = record.get("WEBSITE").trim();
+                if (website.isEmpty()) {
+                    noWebsite++;
+                }
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException("Cannot generate report: " + ex.getMessage(), ex);
+        }
+
+        DecimalFormat pctFormat = (DecimalFormat) DecimalFormat.getNumberInstance(Locale.US);
+        pctFormat.applyPattern("0.00%");
+
+        try (Writer writer = Files.newBufferedWriter(reportPath, StandardCharsets.UTF_8);
+                CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+            printer.printRecord("Name", "Filled with values", "Missing percentage");
+            printer.printRecord("Total number of records in table", total, "");
+            printer.printRecord("Number of records without TYPE field", noType, formatPct(noType, total, pctFormat));
+            printer.printRecord("Number of records without NAME field", noName, formatPct(noName, total, pctFormat));
+            printer.printRecord("Number of records without FULL_ADDRESS field", noFullAddress, formatPct(noFullAddress, total, pctFormat));
+            printer.printRecord("Number of records without LATITUDE field", noLatitude, formatPct(noLatitude, total, pctFormat));
+            printer.printRecord("Number of records without LONGITUDE field", noLongitude, formatPct(noLongitude, total, pctFormat));
+            printer.printRecord("Number of records without RATE field", noRate, formatPct(noRate, total, pctFormat));
+            printer.printRecord("Number of records without REVIEWS field", noReviews, formatPct(noReviews, total, pctFormat));
+            printer.printRecord("Number of records without PHONE field", noPhone, formatPct(noPhone, total, pctFormat));
+            printer.printRecord("Number of records without WEBSITE field", noWebsite, formatPct(noWebsite, total, pctFormat));
+            printer.printRecord("Number of records with broken data format of LATITUDE field", brokenLatitude, formatPct(brokenLatitude, total, pctFormat));
+            printer.printRecord("Number of records with broken data format of LONGITUDE field", brokenLongitude, formatPct(brokenLongitude, total, pctFormat));
+            printer.printRecord("Number of records with broken data format of RATE field", brokenRate, formatPct(brokenRate, total, pctFormat));
+            printer.printRecord("Number of records with broken data format of REVIEWS field", brokenReviews, formatPct(brokenReviews, total, pctFormat));
+            printer.printRecord("Number of records with broken data format of PHONE field", brokenPhone, formatPct(brokenPhone, total, pctFormat));
+        } catch (IOException ex) {
+            throw new RuntimeException("Cannot write report: " + ex.getMessage(), ex);
+        }
+    }
+
+    private boolean isDouble(String value) {
+        try {
+            Double.parseDouble(value);
+            return true;
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+
+    private boolean isInteger(String value) {
+        try {
+            Integer.parseInt(value);
+            return true;
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+
+    private boolean isPhone(String value) {
+        return value.matches("^\\+?[\\d\\s().-]+$") && value.replaceAll("[^\\d]", "").length() > 0;
+    }
+
+    private String formatPct(int count, int total, DecimalFormat formatter) {
+        double pct = total == 0 ? 0d : (double) count / (double) total;
+        return formatter.format(pct);
+    }
+}

--- a/src/test/java/bc/bfi/google_places/ReportGeneratorTest.java
+++ b/src/test/java/bc/bfi/google_places/ReportGeneratorTest.java
@@ -1,0 +1,47 @@
+package bc.bfi.google_places;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+
+public class ReportGeneratorTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void generatesReportWithStatistics() throws IOException {
+        Path data = tempFolder.newFile("initial-.csv").toPath();
+        List<String> lines = Arrays.asList(
+                "GOOGLE_PLACE_CODE,NAME,FULL_ADDRESS,LATITUDE,LONGITUDE,PHONE,WEBSITE,QUERY,RATE,REVIEWS,TYPE",
+                "1,Name1,Address1,40.0,-70.0,+1234567890,https://ex.com,q,4.5,100,restaurant",
+                "2,,Address2,41.0,-71.0,+123-456-7890,,q,not_a_rate,101,bar",
+                "3,Name3,,lat_invalid,long_invalid,abc,https://ex.com,q,3.0,invalid_reviews,"
+        );
+        Files.write(data, lines, StandardCharsets.UTF_8);
+
+        Path report = Paths.get(tempFolder.getRoot().toPath().toString(), "report.csv");
+        new ReportGenerator().generate(data, report);
+
+        List<String> reportLines = Files.readAllLines(report, StandardCharsets.UTF_8);
+        assertThat(reportLines.get(0), is("Name,Filled with values,Missing percentage"));
+        assertThat(reportLines, hasItems(
+                "Total number of records in table,3,",
+                "Number of records without TYPE field,1,33.33%",
+                "Number of records without NAME field,1,33.33%",
+                "Number of records without FULL_ADDRESS field,1,33.33%",
+                "Number of records with broken data format of LATITUDE field,1,33.33%",
+                "Number of records with broken data format of PHONE field,1,33.33%"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- block scraping if `report.csv` already exists
- create `report.csv` after scraping with per-field missing and malformed counts
- add unit test for report statistics

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: jersey-bom:2.27)*

------
https://chatgpt.com/codex/tasks/task_b_6893656414c8832b96e91331ae6d2934