### PR TITLE
Trim whitespace for initial CSV

### DIFF
--- a/src/main/java/bc/bfi/google_places/CsvStorage.java
+++ b/src/main/java/bc/bfi/google_places/CsvStorage.java
@@ -67,17 +67,17 @@ public class CsvStorage {
 
     public void append(Place place) {
         List<String> record = new ArrayList<>();
-        record.add(place.getCid());
-        record.add(place.getName());
-        record.add(place.getFullAddress());
-        record.add(place.getLatitude());
-        record.add(place.getLongitude());
-        record.add(place.getPhone());
-        record.add(place.getWebsite());
-        record.add(place.getQuery());
-        record.add(place.getRate());
-        record.add(place.getRateCounter());
-        record.add(place.getType());
+        record.add(trim(place.getCid()));
+        record.add(trim(place.getName()));
+        record.add(trim(place.getFullAddress()));
+        record.add(trim(place.getLatitude()));
+        record.add(trim(place.getLongitude()));
+        record.add(trim(place.getPhone()));
+        record.add(trim(place.getWebsite()));
+        record.add(trim(place.getQuery()));
+        record.add(trim(place.getRate()));
+        record.add(trim(place.getRateCounter()));
+        record.add(trim(place.getType()));
 
         Path path = Paths.get(STORAGE_FILE);
         try (Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
@@ -95,5 +95,9 @@ public class CsvStorage {
         for (Place place : places) {
             append(place);
         }
+    }
+
+    private String trim(String value) {
+        return value == null ? "" : value.trim();
     }
 }

--- a/src/test/java/bc/bfi/google_places/CsvStorageTest.java
+++ b/src/test/java/bc/bfi/google_places/CsvStorageTest.java
@@ -1,0 +1,71 @@
+package bc.bfi.google_places;
+
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CsvStorageTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void trimsWhitespaceBeforeWriting() throws Exception {
+        Path csvPath = tempFolder.getRoot().toPath().resolve("initial-.csv");
+
+        Field field = CsvStorage.class.getDeclaredField("STORAGE_FILE");
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        String original = (String) field.get(null);
+        field.set(null, csvPath.toString());
+
+        try {
+            CsvStorage storage = new CsvStorage();
+            Place place = new Place();
+            place.setCid(" 123 \n");
+            place.setName(" Name ");
+            place.setFullAddress("\nAddress \r\n");
+            place.setLatitude(" 10.1 ");
+            place.setLongitude(" 20.2 \n");
+            place.setPhone(" +123456 \n");
+            place.setWebsite(" https://ex.com ");
+            place.setQuery(" query ");
+            place.setRate(" 4.5 ");
+            place.setRateCounter(" 10 ");
+            place.setType(" type \n");
+
+            storage.append(place);
+
+            try (Reader reader = Files.newBufferedReader(csvPath, StandardCharsets.UTF_8);
+                    CSVParser parser = new CSVParser(reader, CSVFormat.DEFAULT.withFirstRecordAsHeader())) {
+                CSVRecord record = parser.iterator().next();
+                assertThat(record.get("GOOGLE_PLACE_CODE"), is("123"));
+                assertThat(record.get("NAME"), is("Name"));
+                assertThat(record.get("FULL_ADDRESS"), is("Address"));
+                assertThat(record.get("LATITUDE"), is("10.1"));
+                assertThat(record.get("LONGITUDE"), is("20.2"));
+                assertThat(record.get("PHONE"), is("+123456"));
+                assertThat(record.get("WEBSITE"), is("https://ex.com"));
+                assertThat(record.get("QUERY"), is("query"));
+                assertThat(record.get("RATE"), is("4.5"));
+                assertThat(record.get("REVIEWS"), is("10"));
+                assertThat(record.get("TYPE"), is("type"));
+            }
+        } finally {
+            field.set(null, original);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Trim leading/trailing whitespace (including newlines) from all fields before saving to initial-.csv
- Add unit test ensuring CsvStorage writes sanitized values

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68939e810d18832b9ce2a249bf8bc65f