### PR TITLE
Handle scraping errors without exiting and add file logging

### DIFF
--- a/src/main/java/bc/bfi/google_places/CsvStorage.java
+++ b/src/main/java/bc/bfi/google_places/CsvStorage.java
@@ -1,6 +1,5 @@
 package bc.bfi.google_places;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -8,12 +7,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.JOptionPane;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
@@ -42,7 +40,8 @@ public class CsvStorage {
                 createCsvFile();
             } catch (Exception ex) {
                 LOGGER.log(Level.SEVERE, "Cannot write to .csv file. " + ex.getMessage(), ex);
-                System.exit(1);
+                JOptionPane.showMessageDialog(null, "Cannot write to .csv file.", "Error", JOptionPane.ERROR_MESSAGE);
+                throw new IllegalStateException("Cannot write to .csv file.", ex);
             }
         }
     }
@@ -50,8 +49,10 @@ public class CsvStorage {
     private void createCsvFile() {
         Path path = Paths.get(STORAGE_FILE);
         if (Files.exists(path)) {
-            System.err.println(".csv file already exist: " + path);
-            System.exit(1);
+            String message = ".csv file already exist: " + path;
+            LOGGER.severe(message);
+            JOptionPane.showMessageDialog(null, message, "Error", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalStateException(message);
         }
 
         try (Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
@@ -61,7 +62,8 @@ public class CsvStorage {
             }
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Cannot create .csv file", ex);
-            System.exit(1);
+            JOptionPane.showMessageDialog(null, "Cannot create .csv file", "Error", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalStateException("Cannot create .csv file", ex);
         }
     }
 
@@ -87,7 +89,8 @@ public class CsvStorage {
             }
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Cannot write to .csv file. " + ex.getMessage(), ex);
-            System.exit(1);
+            JOptionPane.showMessageDialog(null, "Cannot write to .csv file.", "Error", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalStateException("Cannot write to .csv file.", ex);
         }
     }
 

--- a/src/main/java/bc/bfi/google_places/JsonStorage.java
+++ b/src/main/java/bc/bfi/google_places/JsonStorage.java
@@ -1,12 +1,6 @@
 package bc.bfi.google_places;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,6 +9,9 @@ import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.JOptionPane;
 
 public class JsonStorage {
 
@@ -28,7 +25,8 @@ public class JsonStorage {
                 Files.createDirectories(JSON_DIRECTORY);
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "Cannot create the JSON directory.", ex);
-                System.exit(1);
+                JOptionPane.showMessageDialog(null, "Cannot create the JSON directory.", "Error", JOptionPane.ERROR_MESSAGE);
+                throw new IllegalStateException("Cannot create the JSON directory.", ex);
             }
         }
     }
@@ -47,9 +45,9 @@ public class JsonStorage {
             Files.write(filePath, json.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE_NEW);
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Cannot save .json file.", ex);
-            System.exit(1);
+            JOptionPane.showMessageDialog(null, "Cannot save .json file.", "Error", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalStateException("Cannot save .json file.", ex);
         }
-
     }
 
 }

--- a/src/main/java/bc/bfi/google_places/LoggerConfig.java
+++ b/src/main/java/bc/bfi/google_places/LoggerConfig.java
@@ -1,0 +1,27 @@
+package bc.bfi.google_places;
+
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+public class LoggerConfig {
+
+    private static final int LIMIT = 10 * 1024 * 1024; // 10 MB
+
+    public static void configure() {
+        configure("application.log", LIMIT);
+    }
+
+    public static void configure(String fileName, int limit) {
+        try {
+            Logger rootLogger = Logger.getLogger("");
+            FileHandler fileHandler = new FileHandler(fileName, limit, 1, true);
+            fileHandler.setFormatter(new SimpleFormatter());
+            rootLogger.addHandler(fileHandler);
+        } catch (IOException ex) {
+            Logger.getLogger(LoggerConfig.class.getName()).log(Level.SEVERE, "Failed to setup logger", ex);
+        }
+    }
+}

--- a/src/main/java/bc/bfi/google_places/Main.java
+++ b/src/main/java/bc/bfi/google_places/Main.java
@@ -243,26 +243,31 @@ public class Main extends javax.swing.JFrame {
 
         System.out.println("SELECTED OPTION: " + this.jComboBoxScraper.getSelectedItem().toString());
 
-        this.jTextFieldStartTime.setText(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        try {
+            this.jTextFieldStartTime.setText(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
 
-        switch (this.jComboBoxScraper.getSelectedItem().toString().toUpperCase()) {
-            case "SERPER.DEV":
-                serperScraper.startScrape();
-                break;
+            switch (this.jComboBoxScraper.getSelectedItem().toString().toUpperCase()) {
+                case "SERPER.DEV":
+                    serperScraper.startScrape();
+                    break;
 
-            case "SERPAPI.COM":
-                serpapiScraper.startScrape();
-                break;
+                case "SERPAPI.COM":
+                    serpapiScraper.startScrape();
+                    break;
 
-            case "GOOGLE.COM/PLACES":
-                googlePlaceScraper.startScrape();
-                break;
+                case "GOOGLE.COM/PLACES":
+                    googlePlaceScraper.startScrape();
+                    break;
+            }
+
+            new ReportGenerator().generate(Paths.get("initial-.csv"), reportPath);
+
+            this.jTextFieldFinishTime.setText(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+            JOptionPane.showMessageDialog(null, "Scrape process completed.", "Done", JOptionPane.INFORMATION_MESSAGE);
+        } catch (RuntimeException ex) {
+            Logger.getLogger(Main.class.getName()).log(Level.SEVERE, "Scrape process failed", ex);
+            JOptionPane.showMessageDialog(null, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
         }
-
-        new ReportGenerator().generate(Paths.get("initial-.csv"), reportPath);
-
-        this.jTextFieldFinishTime.setText(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
-        JOptionPane.showMessageDialog(null, "Scrape process completed.", "Done", JOptionPane.INFORMATION_MESSAGE);
     }//GEN-LAST:event_jButtonStartActionPerformed
 
     private void jComboBoxScraperActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBoxScraperActionPerformed
@@ -345,6 +350,7 @@ public class Main extends javax.swing.JFrame {
     }//GEN-LAST:event_jButtonRescrapeActionPerformed
 
     public static void main(String args[]) {
+        LoggerConfig.configure();
         /* Set the Nimbus look and feel */
         //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
         /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.

--- a/src/main/java/bc/bfi/google_places/scrapers/serpapi/HttpDownloader.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serpapi/HttpDownloader.java
@@ -11,6 +11,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.JOptionPane;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
@@ -50,7 +51,8 @@ class HttpDownloader {
                     .build();
         } catch (URISyntaxException ex) {
             LOGGER.log(Level.SEVERE, "Cannot create URI for serpapi.com service.", ex);
-            System.exit(1);
+            JOptionPane.showMessageDialog(null, "Cannot create URI for serpapi.com service.", "Error", JOptionPane.ERROR_MESSAGE);
+            throw new IllegalStateException("Cannot create URI for serpapi.com service.", ex);
         }
 
         System.out.println("JSON request to service: " + uri.toString());

--- a/src/test/java/bc/bfi/google_places/LoggerConfigTest.java
+++ b/src/test/java/bc/bfi/google_places/LoggerConfigTest.java
@@ -1,0 +1,39 @@
+package bc.bfi.google_places;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class LoggerConfigTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void logFileDoesNotExceedLimit() throws IOException {
+        Path logPath = tempFolder.getRoot().toPath().resolve("test.log");
+        LoggerConfig.configure(logPath.toString(), 1024);
+
+        Logger logger = Logger.getLogger(LoggerConfigTest.class.getName());
+        for (int i = 0; i < 1000; i++) {
+            logger.info("Test message " + i);
+        }
+
+        for (Handler handler : Logger.getLogger("").getHandlers()) {
+            if (handler instanceof FileHandler) {
+                handler.close();
+                Logger.getLogger("").removeHandler(handler);
+            }
+        }
+
+        assertThat(Files.size(logPath), lessThanOrEqualTo(1024L));
+    }
+}


### PR DESCRIPTION
## Summary
- replace `System.exit` calls with alert dialogs and runtime exceptions so scraping stops gracefully instead of terminating the app
- configure a global logger that writes to a local file limited to 10MB and expose configuration for testing
- add unit test verifying log file size constraint

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6894ebb67228832b991319816bd7182c