### PR TITLE
Improve logging clarity

### DIFF
--- a/src/main/java/bc/bfi/google_places/CsvStorage.java
+++ b/src/main/java/bc/bfi/google_places/CsvStorage.java
@@ -39,7 +39,7 @@ public class CsvStorage {
             try {
                 createCsvFile();
             } catch (Exception ex) {
-                LOGGER.log(Level.SEVERE, "Cannot write to .csv file. " + ex.getMessage(), ex);
+                LOGGER.log(Level.SEVERE, "Failed to write to CSV file: " + STORAGE_FILE, ex);
                 JOptionPane.showMessageDialog(null, "Cannot write to .csv file.", "Error", JOptionPane.ERROR_MESSAGE);
                 throw new IllegalStateException("Cannot write to .csv file.", ex);
             }
@@ -49,7 +49,7 @@ public class CsvStorage {
     private void createCsvFile() {
         Path path = Paths.get(STORAGE_FILE);
         if (Files.exists(path)) {
-            String message = ".csv file already exist: " + path;
+            String message = "CSV file already exists: " + path;
             LOGGER.severe(message);
             JOptionPane.showMessageDialog(null, message, "Error", JOptionPane.ERROR_MESSAGE);
             throw new IllegalStateException(message);
@@ -61,7 +61,7 @@ public class CsvStorage {
                 printer.printRecord((Object[]) HEADERS);
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Cannot create .csv file", ex);
+            LOGGER.log(Level.SEVERE, "Failed to create CSV file: " + path, ex);
             JOptionPane.showMessageDialog(null, "Cannot create .csv file", "Error", JOptionPane.ERROR_MESSAGE);
             throw new IllegalStateException("Cannot create .csv file", ex);
         }
@@ -88,7 +88,7 @@ public class CsvStorage {
                 printer.printRecord(record);
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Cannot write to .csv file. " + ex.getMessage(), ex);
+            LOGGER.log(Level.SEVERE, "Failed to write to CSV file: " + path, ex);
             JOptionPane.showMessageDialog(null, "Cannot write to .csv file.", "Error", JOptionPane.ERROR_MESSAGE);
             throw new IllegalStateException("Cannot write to .csv file.", ex);
         }

--- a/src/main/java/bc/bfi/google_places/JsonStorage.java
+++ b/src/main/java/bc/bfi/google_places/JsonStorage.java
@@ -24,7 +24,7 @@ public class JsonStorage {
             try {
                 Files.createDirectories(JSON_DIRECTORY);
             } catch (IOException ex) {
-                LOGGER.log(Level.SEVERE, "Cannot create the JSON directory.", ex);
+                LOGGER.log(Level.SEVERE, "Failed to create JSON directory " + JSON_DIRECTORY, ex);
                 JOptionPane.showMessageDialog(null, "Cannot create the JSON directory.", "Error", JOptionPane.ERROR_MESSAGE);
                 throw new IllegalStateException("Cannot create the JSON directory.", ex);
             }
@@ -44,7 +44,7 @@ public class JsonStorage {
         try {
             Files.write(filePath, json.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE_NEW);
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Cannot save .json file.", ex);
+            LOGGER.log(Level.SEVERE, "Failed to save JSON file " + filePath, ex);
             JOptionPane.showMessageDialog(null, "Cannot save .json file.", "Error", JOptionPane.ERROR_MESSAGE);
             throw new IllegalStateException("Cannot save .json file.", ex);
         }

--- a/src/main/java/bc/bfi/google_places/scrapers/google_places/GooglePlaceScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/google_places/GooglePlaceScraper.java
@@ -20,7 +20,7 @@ public class GooglePlaceScraper {
     }
 
     public void startScrape() {
-        LOGGER.info("Scraping strat");
+        LOGGER.info("Scraping started");
 
         for (String location : this.queries.getQueries()) {
             scrapeLocation(location);
@@ -29,7 +29,7 @@ public class GooglePlaceScraper {
 
     private void scrapeLocation(String query) {
         downloader.createDriver();
-        LOGGER.log(Level.INFO, "Scrape: {0}", query);
+        LOGGER.log(Level.INFO, "Scraping query: {0}", query);
 
         downloader.load(query);
 

--- a/src/main/java/bc/bfi/google_places/scrapers/serpapi/HttpDownloader.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serpapi/HttpDownloader.java
@@ -55,7 +55,7 @@ class HttpDownloader {
             throw new IllegalStateException("Cannot create URI for serpapi.com service.", ex);
         }
 
-        System.out.println("JSON request to service: " + uri.toString());
+        LOGGER.log(Level.INFO, "Requesting URI: {0}", uri);
 
         return uri;
     }
@@ -72,10 +72,10 @@ class HttpDownloader {
                     return EntityUtils.toString(entity, StandardCharsets.UTF_8);
                 }
             } catch (ParseException ex) {
-                LOGGER.log(Level.SEVERE, "Exception during API call.", ex);
+                LOGGER.log(Level.SEVERE, "API call to " + uri + " failed", ex);
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Exception during API call.", ex);
+            LOGGER.log(Level.SEVERE, "API call to " + uri + " failed", ex);
         }
 
         return null;

--- a/src/main/java/bc/bfi/google_places/scrapers/serpapi/SerpapiScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serpapi/SerpapiScraper.java
@@ -24,7 +24,7 @@ public class SerpapiScraper {
     }
 
     public void startScrape() {
-        LOGGER.info("Scraping strat");
+        LOGGER.info("Scraping started");
 
         for (String location : this.queries.getQueries()) {
             scrapeLocation(location);
@@ -32,7 +32,7 @@ public class SerpapiScraper {
     }
 
     private void scrapeLocation(String query) {
-        LOGGER.log(Level.INFO, "Scrape: {0}", query);
+        LOGGER.log(Level.INFO, "Scraping query: {0}", query);
 
         List<Place> places = new ArrayList<>();
         Integer pageNumber = 1;

--- a/src/main/java/bc/bfi/google_places/scrapers/serper/HttpDownloader.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serper/HttpDownloader.java
@@ -41,7 +41,7 @@ class HttpDownloader {
 
         String jsonString = json.toString();
 
-        System.out.println("JSON request to service: " + jsonString);
+        LOGGER.log(Level.INFO, "Sending request payload: {0}", jsonString);
 
         return jsonString;
     }
@@ -59,10 +59,10 @@ class HttpDownloader {
                     return EntityUtils.toString(entity, StandardCharsets.UTF_8);
                 }
             } catch (ParseException ex) {
-                LOGGER.log(Level.SEVERE, "Exception during API call.", ex);
+                LOGGER.log(Level.SEVERE, "API call to " + url + " failed", ex);
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Exception during API call.", ex);
+            LOGGER.log(Level.SEVERE, "API call to " + url + " failed", ex);
         }
 
         return null;

--- a/src/main/java/bc/bfi/google_places/scrapers/serper/SerperScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serper/SerperScraper.java
@@ -27,7 +27,7 @@ public class SerperScraper {
     }
 
     public void startScrape() {
-        LOGGER.info("Scraping strat");
+        LOGGER.info("Scraping started");
         LOGGER.log(Level.INFO, "Total queries: {0}", this.queries.getQueries().size());
 
         for (String location : this.queries.getQueries()) {
@@ -36,7 +36,7 @@ public class SerperScraper {
     }
 
     private void scrapeLocation(String query) {
-        LOGGER.log(Level.INFO, "Scrape: {0}", query);
+        LOGGER.log(Level.INFO, "Scraping query: {0}", query);
 
         List<Place> places = new ArrayList<>();
         Integer pageNumber = 1;


### PR DESCRIPTION
## Summary
- include file and directory details in JSON and CSV error logs
- clarify scrape status and query details in scraper classes
- log request payloads and URIs for API calls with clearer failure messages

## Testing
- `mvn -q test` *(failed: Non-resolvable import POM: Could not transfer artifact org.glassfish.jersey:jersey-bom:pom:2.27 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68963ad05b70832b9321b2ff7357f7f6