### PR TITLE
Configure logger format and bind SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
             <artifactId>commons-codec</artifactId>
             <version>1.14</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+        </dependency>
     
         <!-- Begin QA. -->
         <dependency>

--- a/src/main/java/bc/bfi/google_places/LoggerConfig.java
+++ b/src/main/java/bc/bfi/google_places/LoggerConfig.java
@@ -2,6 +2,7 @@ package bc.bfi.google_places;
 
 import java.io.IOException;
 import java.util.logging.FileHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
@@ -9,14 +10,19 @@ import java.util.logging.SimpleFormatter;
 public class LoggerConfig {
 
     private static final int LIMIT = 10 * 1024 * 1024; // 10 MB
+    private static final String FORMAT = "%1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS %1$Tp %2$s %4$s: %5$s%6$s%n";
 
     public static void configure() {
         configure("application.log", LIMIT);
     }
 
     public static void configure(String fileName, int limit) {
+        System.setProperty("java.util.logging.SimpleFormatter.format", FORMAT);
         try {
             Logger rootLogger = Logger.getLogger("");
+            for (Handler handler : rootLogger.getHandlers()) {
+                handler.setFormatter(new SimpleFormatter());
+            }
             FileHandler fileHandler = new FileHandler(fileName, limit, 1, true);
             fileHandler.setFormatter(new SimpleFormatter());
             rootLogger.addHandler(fileHandler);

--- a/src/test/java/bc/bfi/google_places/LoggerConfigTest.java
+++ b/src/test/java/bc/bfi/google_places/LoggerConfigTest.java
@@ -3,6 +3,7 @@ package bc.bfi.google_places;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
@@ -10,6 +11,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class LoggerConfigTest {
@@ -35,5 +38,18 @@ public class LoggerConfigTest {
         }
 
         assertThat(Files.size(logPath), lessThanOrEqualTo(1024L));
+    }
+
+    @Test
+    public void logsAreWrittenOnSingleLine() throws IOException {
+        Path logPath = tempFolder.getRoot().toPath().resolve("single.log");
+        LoggerConfig.configure(logPath.toString(), 1024);
+
+        Logger logger = Logger.getLogger(LoggerConfigTest.class.getName());
+        logger.info("Test message");
+
+        List<String> lines = Files.readAllLines(logPath);
+        assertThat(lines, hasSize(1));
+        assertThat(lines.get(0), containsString("INFO: Test message"));
     }
 }


### PR DESCRIPTION
## Summary
- ensure java.util.logging outputs on a single line by configuring SimpleFormatter
- add slf4j-simple to satisfy SLF4J binder and suppress warnings
- extend LoggerConfig tests to verify log size and one-line formatting

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.glassfish.jersey:jersey-bom:pom:2.27: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68964e5ccd50832b9fc1ac949bf70f0e