### PR TITLE
Trim package names from log output

### DIFF
--- a/src/main/java/bc/bfi/google_places/LoggerConfig.java
+++ b/src/main/java/bc/bfi/google_places/LoggerConfig.java
@@ -5,26 +5,24 @@ import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 
 public class LoggerConfig {
 
     private static final int LIMIT = 10 * 1024 * 1024; // 10 MB
-    private static final String FORMAT = "%1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS %1$Tp %2$s %4$s: %5$s%6$s%n";
 
     public static void configure() {
         configure("application.log", LIMIT);
     }
 
     public static void configure(String fileName, int limit) {
-        System.setProperty("java.util.logging.SimpleFormatter.format", FORMAT);
+        ShortClassNameFormatter formatter = new ShortClassNameFormatter();
         try {
             Logger rootLogger = Logger.getLogger("");
             for (Handler handler : rootLogger.getHandlers()) {
-                handler.setFormatter(new SimpleFormatter());
+                handler.setFormatter(formatter);
             }
             FileHandler fileHandler = new FileHandler(fileName, limit, 1, true);
-            fileHandler.setFormatter(new SimpleFormatter());
+            fileHandler.setFormatter(formatter);
             rootLogger.addHandler(fileHandler);
         } catch (IOException ex) {
             Logger.getLogger(LoggerConfig.class.getName()).log(Level.SEVERE, "Failed to setup logger", ex);

--- a/src/main/java/bc/bfi/google_places/ShortClassNameFormatter.java
+++ b/src/main/java/bc/bfi/google_places/ShortClassNameFormatter.java
@@ -1,0 +1,53 @@
+package bc.bfi.google_places;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * Formatter that prints only the simple class name in log messages.
+ */
+public class ShortClassNameFormatter extends Formatter {
+
+    private static final String FORMAT = "%1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS %1$Tp %2$s %4$s: %5$s%6$s%n";
+
+    @Override
+    public synchronized String format(LogRecord record) {
+        String source;
+        if (record.getSourceClassName() != null) {
+            String className = record.getSourceClassName();
+            int lastDot = className.lastIndexOf('.');
+            if (lastDot >= 0) {
+                className = className.substring(lastDot + 1);
+            }
+            source = className;
+            if (record.getSourceMethodName() != null) {
+                source += " " + record.getSourceMethodName();
+            }
+        } else {
+            source = record.getLoggerName();
+        }
+
+        String throwable = "";
+        if (record.getThrown() != null) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            record.getThrown().printStackTrace(pw);
+            pw.close();
+            throwable = sw.toString();
+        }
+
+        return String.format(
+                FORMAT,
+                new Date(record.getMillis()),
+                source,
+                record.getLoggerName(),
+                record.getLevel().getLocalizedName(),
+                formatMessage(record),
+                throwable
+        );
+    }
+}
+

--- a/src/test/java/bc/bfi/google_places/LoggerConfigTest.java
+++ b/src/test/java/bc/bfi/google_places/LoggerConfigTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 
 public class LoggerConfigTest {
 
@@ -51,5 +52,19 @@ public class LoggerConfigTest {
         List<String> lines = Files.readAllLines(logPath);
         assertThat(lines, hasSize(1));
         assertThat(lines.get(0), containsString("INFO: Test message"));
+    }
+
+    @Test
+    public void logLineContainsSimpleClassName() throws IOException {
+        Path logPath = tempFolder.getRoot().toPath().resolve("classname.log");
+        LoggerConfig.configure(logPath.toString(), 1024);
+
+        Logger logger = Logger.getLogger(LoggerConfigTest.class.getName());
+        logger.info("Simple message");
+
+        List<String> lines = Files.readAllLines(logPath);
+        assertThat(lines, hasSize(1));
+        assertThat(lines.get(0), containsString("LoggerConfigTest logLineContainsSimpleClassName INFO: Simple message"));
+        assertThat(lines.get(0), not(containsString("bc.bfi.google_places.LoggerConfigTest")));
     }
 }


### PR DESCRIPTION
## Summary
- add `ShortClassNameFormatter` to remove package prefixes from `java.util.logging` output
- apply the new formatter in `LoggerConfig`
- test that log lines contain only simple class names

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6896523836d8832b84c9b995485b7949