### PR TITLE
Track scraping duration in CSV output

### DIFF
--- a/src/main/java/bc/bfi/google_places/CsvStorage.java
+++ b/src/main/java/bc/bfi/google_places/CsvStorage.java
@@ -31,7 +31,8 @@ public class CsvStorage {
         "QUERY",
         "RATE",
         "REVIEWS",
-        "TYPE"
+        "TYPE",
+        "DURATION"
     };
 
     public CsvStorage() {
@@ -80,6 +81,7 @@ public class CsvStorage {
         record.add(trim(place.getRate()));
         record.add(trim(place.getRateCounter()));
         record.add(trim(place.getType()));
+        record.add(trim(place.getDuration()));
 
         Path path = Paths.get(STORAGE_FILE);
         try (Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {

--- a/src/main/java/bc/bfi/google_places/Place.java
+++ b/src/main/java/bc/bfi/google_places/Place.java
@@ -15,6 +15,7 @@ public class Place {
     private String socialLinks = "";
     private String cid = "";
     private String website = "";
+    private String duration = "";
 
     public String getWebsite() {
         return website;
@@ -22,6 +23,14 @@ public class Place {
 
     public void setWebsite(String website) {
         this.website = website;
+    }
+
+    public String getDuration() {
+        return duration;
+    }
+
+    public void setDuration(String duration) {
+        this.duration = duration;
     }
 
     public String getFullAddress() {
@@ -134,6 +143,7 @@ public class Place {
         System.out.println("Social links: " + socialLinks);
         System.out.println("CID: " + cid);
         System.out.println("Website: " + website);
+        System.out.println("Duration: " + duration);
     }
 
 }

--- a/src/main/java/bc/bfi/google_places/scrapers/google_places/GooglePlaceScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/google_places/GooglePlaceScraper.java
@@ -35,11 +35,16 @@ public class GooglePlaceScraper {
 
         while (true) {
             // Go through all 10 places shown on the page.
-            while (downloader.loadNextPlaceProfile()) {
-                String webPage = downloader.fetchWebPage();
-                Place place = parser.parsePlaceProfile(webPage, downloader.getPlaceCard());
-                csvStorage.append(place);
+        while (true) {
+            long start = System.currentTimeMillis();
+            if (!downloader.loadNextPlaceProfile()) {
+                break;
             }
+            String webPage = downloader.fetchWebPage();
+            Place place = parser.parsePlaceProfile(webPage, downloader.getPlaceCard());
+            place.setDuration(String.valueOf(System.currentTimeMillis() - start));
+            csvStorage.append(place);
+        }
             
             if(downloader.hasNextPage()){
                downloader.loadNextPage(); 

--- a/src/main/java/bc/bfi/google_places/scrapers/serpapi/SerpapiScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serpapi/SerpapiScraper.java
@@ -37,9 +37,14 @@ public class SerpapiScraper {
         List<Place> places = new ArrayList<>();
         Integer pageNumber = 1;
         while (true) {
+            long start = System.currentTimeMillis();
             String jsonResponse = downloader.searchPlaces(query, pageNumber, "google.com", "us", "en");
+            long duration = System.currentTimeMillis() - start;
             jsonStorage.save(jsonResponse);
             places = parser.parse(jsonResponse, query);
+            for (Place place : places) {
+                place.setDuration(String.valueOf(duration));
+            }
             csvStorage.append(places);
 
             if (places.size() != 20) {

--- a/src/main/java/bc/bfi/google_places/scrapers/serper/SerperScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serper/SerperScraper.java
@@ -41,9 +41,14 @@ public class SerperScraper {
         List<Place> places = new ArrayList<>();
         Integer pageNumber = 1;
         while (true) {
+            long start = System.currentTimeMillis();
             String jsonResponse = downloader.searchPlaces(query, pageNumber, config.getLocation(), config.getCountry(), config.getLanguage());
+            long duration = System.currentTimeMillis() - start;
             jsonStorage.save(jsonResponse);
             places = parser.parse(jsonResponse, query);
+            for (Place place : places) {
+                place.setDuration(String.valueOf(duration));
+            }
             csvStorage.append(places);
 
             if (places.size() != 10) {

--- a/src/test/java/bc/bfi/google_places/CsvStorageTest.java
+++ b/src/test/java/bc/bfi/google_places/CsvStorageTest.java
@@ -47,6 +47,7 @@ public class CsvStorageTest {
             place.setRate(" 4.5 ");
             place.setRateCounter(" 10 ");
             place.setType(" type \n");
+            place.setDuration(" 1000 ");
 
             storage.append(place);
 
@@ -64,6 +65,7 @@ public class CsvStorageTest {
                 assertThat(record.get("RATE"), is("4.5"));
                 assertThat(record.get("REVIEWS"), is("10"));
                 assertThat(record.get("TYPE"), is("type"));
+                assertThat(record.get("DURATION"), is("1000"));
             }
         } finally {
             field.set(null, original);

--- a/src/test/java/bc/bfi/google_places/ReportGeneratorTest.java
+++ b/src/test/java/bc/bfi/google_places/ReportGeneratorTest.java
@@ -23,10 +23,10 @@ public class ReportGeneratorTest {
     public void generatesReportWithStatistics() throws IOException {
         Path data = tempFolder.newFile("initial-.csv").toPath();
         List<String> lines = Arrays.asList(
-                "GOOGLE_PLACE_CODE,NAME,FULL_ADDRESS,LATITUDE,LONGITUDE,PHONE,WEBSITE,QUERY,RATE,REVIEWS,TYPE",
-                "1,Name1,Address1,40.0,-70.0,+1234567890,https://ex.com,q,4.5,100,restaurant",
-                "2,,Address2,41.0,-71.0,+123-456-7890,,q,not_a_rate,101,bar",
-                "3,Name3,,lat_invalid,long_invalid,abc,https://ex.com,q,3.0,invalid_reviews,"
+                "GOOGLE_PLACE_CODE,NAME,FULL_ADDRESS,LATITUDE,LONGITUDE,PHONE,WEBSITE,QUERY,RATE,REVIEWS,TYPE,DURATION",
+                "1,Name1,Address1,40.0,-70.0,+1234567890,https://ex.com,q,4.5,100,restaurant,10",
+                "2,,Address2,41.0,-71.0,+123-456-7890,,q,not_a_rate,101,bar,20",
+                "3,Name3,,lat_invalid,long_invalid,abc,https://ex.com,q,3.0,invalid_reviews,,30"
         );
         Files.write(data, lines, StandardCharsets.UTF_8);
 

--- a/src/test/java/bc/bfi/google_places/scrapers/serper/SerperScraperTest.java
+++ b/src/test/java/bc/bfi/google_places/scrapers/serper/SerperScraperTest.java
@@ -1,0 +1,61 @@
+package bc.bfi.google_places.scrapers.serper;
+
+import bc.bfi.google_places.Place;
+import bc.bfi.google_places.CsvStorage;
+import bc.bfi.google_places.JsonStorage;
+import bc.bfi.google_places.scrapers.Config;
+import bc.bfi.google_places.scrapers.Queries;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that SerperScraper populates duration for scraped places.
+ */
+public class SerperScraperTest {
+
+    @Test
+    public void setsDurationForEachPlace() throws Exception {
+        Queries queries = new Queries();
+        queries.loadQueries("test");
+        Config config = new Config();
+        config.load("us", "en", "Austin");
+        SerperScraper scraper = new SerperScraper(queries, config);
+
+        HttpDownloader downloader = mock(HttpDownloader.class);
+        when(downloader.searchPlaces(anyString(), anyInt(), anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> { Thread.sleep(50); return "{}"; });
+
+        Parser parser = mock(Parser.class);
+        Place place = new Place();
+        when(parser.parse(anyString(), anyString())).thenReturn(Collections.singletonList(place));
+
+        CsvStorage csv = mock(CsvStorage.class);
+        JsonStorage json = mock(JsonStorage.class);
+
+        setField(scraper, "downloader", downloader);
+        setField(scraper, "parser", parser);
+        setField(scraper, "csvStorage", csv);
+        setField(scraper, "jsonStorage", json);
+
+        scraper.startScrape();
+
+        assertThat(Long.parseLong(place.getDuration()), greaterThan(0L));
+    }
+
+    private void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## Summary
- Record elapsed scraping time per place and store it as a new DURATION column in result CSV
- Measure request timings across Google Place, SerpAPI and Serper scrapers and expose duration via Place model
- Extend tests to cover duration handling and add SerperScraper unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: jersey-bom:2.27)*

------
https://chatgpt.com/codex/tasks/task_b_68967f389ff8832bad0312be415c7882