### PR TITLE
Add retry logic for Serper requests

### DIFF
--- a/src/test/java/bc/bfi/google_places/scrapers/serper/HttpDownloaderTest.java
+++ b/src/test/java/bc/bfi/google_places/scrapers/serper/HttpDownloaderTest.java
@@ -1,0 +1,49 @@
+package bc.bfi.google_places.scrapers.serper;
+
+import java.io.IOException;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import org.mockito.Mockito;
+
+public class HttpDownloaderTest {
+
+    @Test
+    public void shouldRetryAndReturnResponseAfterNetworkIssues() throws Exception {
+        HttpDownloader downloader = Mockito.spy(new HttpDownloader());
+        Mockito.doThrow(new IOException())
+                .doThrow(new IOException())
+                .doReturn("ok")
+                .when(downloader).executePost(Mockito.anyString(), Mockito.anyString());
+        Mockito.doNothing().when(downloader).pause(Mockito.anyLong());
+        Mockito.doNothing().when(downloader).showError(Mockito.anyString());
+
+        String result = downloader.sendPostRequest("url", "{}");
+
+        assertThat(result, is("ok"));
+        Mockito.verify(downloader, Mockito.times(3)).executePost(Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(downloader, Mockito.times(2)).pause(Mockito.anyLong());
+        Mockito.verify(downloader, Mockito.never()).showError(Mockito.anyString());
+    }
+
+    @Test
+    public void shouldShowErrorAfterThreeFailedRetries() throws Exception {
+        HttpDownloader downloader = Mockito.spy(new HttpDownloader());
+        Mockito.doThrow(new IOException())
+                .doThrow(new IOException())
+                .doThrow(new IOException())
+                .doThrow(new IOException())
+                .when(downloader).executePost(Mockito.anyString(), Mockito.anyString());
+        Mockito.doNothing().when(downloader).pause(Mockito.anyLong());
+        Mockito.doNothing().when(downloader).showError(Mockito.anyString());
+
+        String result = downloader.sendPostRequest("url", "{}");
+
+        assertThat(result, nullValue());
+        Mockito.verify(downloader, Mockito.times(4)).executePost(Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(downloader).pause(5000L);
+        Mockito.verify(downloader).pause(15000L);
+        Mockito.verify(downloader).pause(60000L);
+        Mockito.verify(downloader).showError(Mockito.anyString());
+    }
+}


### PR DESCRIPTION
## Summary
- add retry mechanism with escalating delays for Serper API network errors
- show popup alert after final failure and log the issue
- cover retry behavior with Mockito-based unit tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689758db01d0832bb7f56adce3ce52c8