### PR TITLE
Display completion banner

### DIFF
--- a/src/main/java/bc/bfi/google_places/BannerPrinter.java
+++ b/src/main/java/bc/bfi/google_places/BannerPrinter.java
@@ -1,0 +1,30 @@
+package bc.bfi.google_places;
+
+/**
+ * Utility class that prints a banner to the console when the scraping
+ * process has finished.
+ */
+public final class BannerPrinter {
+
+    private BannerPrinter() {
+        // Utility class
+    }
+
+    /**
+     * The banner that indicates successful completion of the scraping process.
+     */
+    public static final String BANNER = String.join(System.lineSeparator(),
+            "-------------------------------------- =========== --------------------------------------",
+            "",
+            "             SCRAPING PROCESS HAS BEEN COMPLETED SUCCESSFULLY",
+            "",
+            "-------------------------------------- =========== --------------------------------------");
+
+    /**
+     * Print the banner to the standard output.
+     */
+    public static void printBanner() {
+        System.out.println(BANNER);
+    }
+}
+

--- a/src/main/java/bc/bfi/google_places/Main.java
+++ b/src/main/java/bc/bfi/google_places/Main.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.List;
+import bc.bfi.google_places.BannerPrinter;
 
 public class Main extends javax.swing.JFrame {
 
@@ -263,7 +264,8 @@ public class Main extends javax.swing.JFrame {
             new ReportGenerator().generate(Paths.get("initial-.csv"), reportPath);
 
             this.jTextFieldFinishTime.setText(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
-            JOptionPane.showMessageDialog(null, "Scrape process completed.", "Done", JOptionPane.INFORMATION_MESSAGE);
+            BannerPrinter.printBanner();
+            JOptionPane.showMessageDialog(null, "Scrape process completed successfully.", "Done", JOptionPane.INFORMATION_MESSAGE);
         } catch (RuntimeException ex) {
             Logger.getLogger(Main.class.getName()).log(Level.SEVERE, "Scrape process failed", ex);
             JOptionPane.showMessageDialog(null, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);

--- a/src/test/java/bc/bfi/google_places/BannerPrinterTest.java
+++ b/src/test/java/bc/bfi/google_places/BannerPrinterTest.java
@@ -1,0 +1,25 @@
+package bc.bfi.google_places;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BannerPrinterTest {
+
+    @Test
+    public void printBannerOutputsExpectedMessage() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+        try {
+            BannerPrinter.printBanner();
+        } finally {
+            System.setOut(original);
+        }
+        String expected = BannerPrinter.BANNER + System.lineSeparator();
+        assertThat(out.toString(), is(expected));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `BannerPrinter` utility to print a completion banner to the console
- update `Main` to invoke banner and show success popup
- test that the banner is printed as expected

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68975a3dc2c0832bb3aa6140907ff053