### PR TITLE
Generate report on re-scrape

### DIFF
--- a/src/main/java/bc/bfi/google_places/Main.java
+++ b/src/main/java/bc/bfi/google_places/Main.java
@@ -8,6 +8,7 @@ import bc.bfi.google_places.scrapers.google_places.GooglePlaceScraper;
 import bc.bfi.google_places.scrapers.serpapi.SerpapiScraper;
 import bc.bfi.google_places.scrapers.serper.Parser;
 import bc.bfi.google_places.scrapers.serper.SerperScraper;
+import java.awt.HeadlessException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -345,6 +346,14 @@ public class Main extends javax.swing.JFrame {
 
                 List<Place> places = parser.parse(json);
                 csvStorage.append(places);
+            }
+
+            new ReportGenerator().generate(Paths.get("initial-.csv"), Paths.get("report-.csv"));
+            System.out.println("Re-processing completed");
+            try {
+                JOptionPane.showMessageDialog(null, "Re-processing completed", "Done", JOptionPane.INFORMATION_MESSAGE);
+            } catch (HeadlessException ex) {
+                // ignore when running in headless environment
             }
         } catch (IOException | DirectoryIteratorException e) {
             e.printStackTrace();

--- a/src/test/java/bc/bfi/google_places/MainRescrapeTest.java
+++ b/src/test/java/bc/bfi/google_places/MainRescrapeTest.java
@@ -1,0 +1,80 @@
+package bc.bfi.google_places;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Comparator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class MainRescrapeTest {
+
+    @Before
+    public void setUp() throws IOException {
+        System.setProperty("java.awt.headless", "true");
+        // Prepare json directory with a sample file
+        Path jsonDir = Paths.get("json");
+        if (!Files.exists(jsonDir)) {
+            Files.createDirectory(jsonDir);
+        }
+        String json = "{\n" +
+                "  \"searchParameters\": {\"q\": \"query\"},\n" +
+                "  \"places\": [{\n" +
+                "    \"title\": \"Name1\",\n" +
+                "    \"address\": \"Address1\",\n" +
+                "    \"latitude\": 10.0,\n" +
+                "    \"longitude\": 20.0,\n" +
+                "    \"rating\": 4.5,\n" +
+                "    \"ratingCount\": 10,\n" +
+                "    \"category\": \"type1\",\n" +
+                "    \"website\": \"https://ex.com\",\n" +
+                "    \"cid\": \"cid1\",\n" +
+                "    \"phoneNumber\": \"+123456\"\n" +
+                "  }]\n" +
+                "}";
+        Files.write(jsonDir.resolve("data.json"), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        Files.deleteIfExists(Paths.get("initial-.csv"));
+        Files.deleteIfExists(Paths.get("report-.csv"));
+        Path jsonDir = Paths.get("json");
+        if (Files.exists(jsonDir)) {
+            Files.walk(jsonDir)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(java.io.File::delete);
+        }
+    }
+
+    @Test
+    public void generatesReportAndLogsCompletion() throws Exception {
+        Main main = new Main();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        // invoke the private action method
+        java.lang.reflect.Method method = Main.class.getDeclaredMethod("jButtonRescrapeActionPerformed", java.awt.event.ActionEvent.class);
+        method.setAccessible(true);
+        method.invoke(main, new Object[]{null});
+
+        System.setOut(originalOut);
+
+        Path reportPath = Paths.get("report-.csv");
+        assertThat(Files.exists(reportPath), is(true));
+        List<String> lines = Files.readAllLines(reportPath, StandardCharsets.UTF_8);
+        assertThat(lines.get(0), is("Name,Missing values,Missing percentage"));
+        assertThat(out.toString(), containsString("Re-processing completed"));
+    }
+}


### PR DESCRIPTION
## Summary
- Create a report after running the Re-scrape action
- Display and log a completion message when re-processing finishes
- Test that re-scraping produces a report and logs completion

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.glassfish.jersey:jersey-bom:pom:2.27)*

------
https://chatgpt.com/codex/tasks/task_b_689761776e4c832baeb31832630df8d5