### PR TITLE
Add empty value tracking to Serper scraper

### DIFF
--- a/src/main/java/bc/bfi/google_places/scrapers/serper/SerperScraper.java
+++ b/src/main/java/bc/bfi/google_places/scrapers/serper/SerperScraper.java
@@ -6,7 +6,9 @@ import bc.bfi.google_places.Place;
 import bc.bfi.google_places.scrapers.Config;
 import bc.bfi.google_places.scrapers.Queries;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -21,9 +23,28 @@ public class SerperScraper {
     private final Queries queries;
     private final Config config;
 
+    private final Map<String, Integer> emptyCounters = new HashMap<>();
+    private final Map<String, Integer> emptyLimits = new HashMap<>();
+
     public SerperScraper(final Queries queries, final Config config) {
         this.queries = queries;
         this.config = config;
+
+        emptyLimits.put("fullAddress", 50);
+        emptyLimits.put("latitude", 30);
+        emptyLimits.put("longitude", 30);
+        emptyLimits.put("name", 30);
+        emptyLimits.put("phone", 100);
+        emptyLimits.put("query", 20);
+        emptyLimits.put("rate", 50);
+        emptyLimits.put("rateCounter", 50);
+        emptyLimits.put("type", 30);
+        emptyLimits.put("cid", 30);
+        emptyLimits.put("website", 100);
+
+        for (String key : emptyLimits.keySet()) {
+            emptyCounters.put(key, 0);
+        }
     }
 
     public void startScrape() {
@@ -44,6 +65,7 @@ public class SerperScraper {
             String jsonResponse = downloader.searchPlaces(query, pageNumber, config.getLocation(), config.getCountry(), config.getLanguage());
             jsonStorage.save(jsonResponse);
             places = parser.parse(jsonResponse, query);
+            checkEmptyValues(places);
             csvStorage.append(places);
 
             if (places.size() != 10) {
@@ -53,6 +75,33 @@ public class SerperScraper {
                 break;
             }
             pageNumber += 1;
+        }
+    }
+
+    void checkEmptyValues(List<Place> places) {
+        for (Place place : places) {
+            increment("fullAddress", place.getFullAddress());
+            increment("latitude", place.getLatitude());
+            increment("longitude", place.getLongitude());
+            increment("name", place.getName());
+            increment("phone", place.getPhone());
+            increment("query", place.getQuery());
+            increment("rate", place.getRate());
+            increment("rateCounter", place.getRateCounter());
+            increment("type", place.getType());
+            increment("cid", place.getCid());
+            increment("website", place.getWebsite());
+        }
+    }
+
+    private void increment(String field, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            int count = emptyCounters.get(field) + 1;
+            emptyCounters.put(field, count);
+            if (count > emptyLimits.get(field)) {
+                LOGGER.severe("Serper returns many empty values for one of field.");
+                throw new RuntimeException("Serper returns many empty values for one of field.");
+            }
         }
     }
 

--- a/src/test/java/bc/bfi/google_places/scrapers/serper/SerperScraperTest.java
+++ b/src/test/java/bc/bfi/google_places/scrapers/serper/SerperScraperTest.java
@@ -1,0 +1,49 @@
+package bc.bfi.google_places.scrapers.serper;
+
+import bc.bfi.google_places.Place;
+import bc.bfi.google_places.scrapers.Config;
+import bc.bfi.google_places.scrapers.Queries;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+public class SerperScraperTest {
+
+    @Test
+    public void shouldThrowWhenQueryEmptyExceedsLimit() {
+        SerperScraper scraper = new SerperScraper(new Queries(), new Config());
+
+        List<Place> firstBatch = buildPlaces(20);
+        scraper.checkEmptyValues(firstBatch);
+
+        List<Place> nextBatch = buildPlaces(1);
+        try {
+            scraper.checkEmptyValues(nextBatch);
+            fail("Expected RuntimeException");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), is("Serper returns many empty values for one of field."));
+        }
+    }
+
+    private List<Place> buildPlaces(int count) {
+        List<Place> places = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Place p = new Place();
+            p.setFullAddress("addr");
+            p.setLatitude("1");
+            p.setLongitude("1");
+            p.setName("name");
+            p.setPhone("123");
+            p.setRate("1");
+            p.setRateCounter("1");
+            p.setType("type");
+            p.setCid("cid");
+            p.setWebsite("site");
+            places.add(p);
+        }
+        return places;
+    }
+}


### PR DESCRIPTION
## Summary
- track empty field counts when scraping with Serper
- stop scraping when a field exceeds configured empty count limit
- add unit test covering query field threshold

## Testing
- `mvn test` *(fails: Non-resolvable import POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a88feebdd4832ba2a9bfd1f0f0eeac